### PR TITLE
🛠 AttributeError: 'str' object has no attribute 'get' ✅

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,10 +8,12 @@ import disnake
 from disnake.ext import commands
 
 from utils.load_environement import load_enviroment_lang, load_enviroment_token
-from utils.load_lang import main_lang as lang
+from utils.load_lang import main_lang
 from data.var import *
 
 
+
+lang = main_lang
 
 if not os.path.exists(configFilesFolder):
     os.mkdir(configFilesFolder)
@@ -37,7 +39,7 @@ if not os.path.exists(envFilePath):
         }
         json.dump(envData, env_file, indent=4)
 
-lang = load_enviroment_lang()
+lang = main_lang
 
 if not os.path.exists(badWordFilePath):
     badword_data = {


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a bug where an AttributeError was raised due to the 'lang' variable being incorrectly assigned. The fix ensures that 'lang' is correctly set to 'main_lang' from the 'utils.load_lang' module.

- **Bug Fixes**:
    - Fixed an AttributeError caused by incorrect assignment of 'lang' variable.

<!-- Generated by sourcery-ai[bot]: end summary -->