### PR TITLE
Dev

### DIFF
--- a/cogs/casino/earn.py
+++ b/cogs/casino/earn.py
@@ -60,8 +60,6 @@ class EarnCommand(commands.Cog):
                     title=langText.get("EARN_COOLDOWN_TITLE"),
                     description=formatted_cooldown_text,
                     color=disnake.Color.red())
-
-            await ctx.response.defer()
             await ctx.send(embed=embed)
         except Exception as e:
             embed = error.error_embed(e)

--- a/cogs/mods/clear.py
+++ b/cogs/mods/clear.py
@@ -20,15 +20,13 @@ class ClearCommand(commands.Cog):
     @commands.has_permissions(manage_messages=True)
     async def clear(self, ctx, amount: int):
         try:
-            await ctx.response.defer()
             await ctx.channel.purge(limit=amount+1)
 
             embed = disnake.Embed(
                 title=langText.get("CLEAR_TITLE"),
                 description=langText.get("CLEAR_TEXT").format(amount=amount),
                 color=disnake.Color.brand_green())
-            message = await ctx.send(embed=embed, delete_after=3)
-            await ctx.response.send_message(message)
+            await ctx.send(embed=embed, delete_after=3)
 
         except Exception as e:
             embed = error.error_embed(e)

--- a/cogs/mods/clear.py
+++ b/cogs/mods/clear.py
@@ -8,7 +8,6 @@ from utils import error
 from utils.load_lang import mods_lang as langText
 
 
-
 class ClearCommand(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
@@ -28,7 +27,8 @@ class ClearCommand(commands.Cog):
                 title=langText.get("CLEAR_TITLE"),
                 description=langText.get("CLEAR_TEXT").format(amount=amount),
                 color=disnake.Color.brand_green())
-            await ctx.send(embed=embed, delete_after=3)
+            message = await ctx.send(embed=embed, delete_after=3)
+            await ctx.response.send_message(message)
 
         except Exception as e:
             embed = error.error_embed(e)

--- a/cogs/owner/stop.py
+++ b/cogs/owner/stop.py
@@ -18,8 +18,7 @@ class StopCommand(commands.Cog):
     async def stop(self, ctx):
         try:
             await ctx.send(langText.get("STOP_TITLE"), ephemeral=True)
-            # await self.bot.close()
-            exit(code=1)
+            await self.bot.close()
         except Exception as e:
             embed = error.error_embed(e)
             await ctx.send(embed=embed)

--- a/cogs/owner/stop.py
+++ b/cogs/owner/stop.py
@@ -18,7 +18,7 @@ class StopCommand(commands.Cog):
     async def stop(self, ctx):
         try:
             await ctx.send(langText.get("STOP_TITLE"), ephemeral=True)
-            await self.bot.close()
+            # await self.bot.close()
             exit(code=1)
         except Exception as e:
             embed = error.error_embed(e)


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request focuses on cleaning up the code by removing unnecessary `ctx.response.defer()` calls in the `earn`, `clear`, and `stop` commands, and eliminating a redundant exit call in the `stop` command.

- **Bug Fixes**:
    - Removed unnecessary `ctx.response.defer()` calls in `earn`, `clear`, and `stop` commands to prevent potential issues with deferred responses.
- **Enhancements**:
    - Cleaned up code by removing redundant exit call in the `stop` command.

<!-- Generated by sourcery-ai[bot]: end summary -->